### PR TITLE
Move platform code to separate modules

### DIFF
--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,0 +1,13 @@
+use crate::Result;
+
+#[link(name = "login", kind = "framework")]
+extern "C" {
+    fn SACLockScreenImmediate();
+}
+
+pub fn lock_screen_mac() -> Result<()> {
+    unsafe {
+        SACLockScreenImmediate();
+        Ok(())
+    }
+}

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,0 +1,21 @@
+use crate::{Result, Win32ErrorCode};
+
+#[link(name = "user32")]
+extern "system" {
+    fn LockWorkStation() -> i32;
+}
+
+#[link(name = "Kernel32")]
+extern "system" {
+    fn GetLastError() -> Win32ErrorCode;
+}
+
+pub fn lock_screen_windows() -> Result<()> {
+    unsafe {
+        if 0 == LockWorkStation() {
+            Err(Error::Win32(GetLastError()))
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,4 +1,4 @@
-use crate::{Result, Win32ErrorCode};
+use crate::{Error, Result, Win32ErrorCode};
 
 #[link(name = "user32")]
 extern "system" {


### PR DESCRIPTION
Separate out platform specific code into separate platform modules, and leave the platform independent "common" code as is. This should reduce the noise from various platforms in mod.rs, especially once Linux or other platforms are added.