### PR TITLE
add additional default commands listed in xubuntu's xflock4

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -8,7 +8,12 @@ struct LockCommand<'a> {
     args: &'a [&'a str],
 }
 
-static DEFAULT_COMMANDS: [LockCommand; 6] = [
+static DEFAULT_COMMANDS: [LockCommand; 10] = [
+    // xfce4-screensaver must be tried before xdg-screensaver to ensure success on XUbuntu
+    LockCommand {
+        exe: "/usr/bin/xfce4-screensaver-command",
+        args: &["--lock"],
+    },
     LockCommand {
         exe: "/usr/bin/xdg-screensaver",
         args: &["lock"],
@@ -22,8 +27,16 @@ static DEFAULT_COMMANDS: [LockCommand; 6] = [
         args: &["org.freedesktop.ScreenSaver", "/ScreenSaver", "Lock"],
     },
     LockCommand {
+        exe: "/usr/bin/light-locker-command",
+        args: &["-lock"],
+    },
+    LockCommand {
         exe: "/usr/bin/xscreensaver-command",
         args: &["-lock"],
+    },
+    LockCommand {
+        exe: "/usr/bin/mate-screensaver-command",
+        args: &["--lock"],
     },
     LockCommand {
         exe: "/usr/bin/xlock",
@@ -32,6 +45,10 @@ static DEFAULT_COMMANDS: [LockCommand; 6] = [
     LockCommand {
         exe: "/usr/bin/slock",
         args: &[],
+    },
+    LockCommand {
+        exe: "/usr/bin/physlock",
+        args: &["-d"],
     },
 ];
 


### PR DESCRIPTION
This adds additional default commands, taken from the [xflock4](https://github.com/xfce-mirror/xfce4-session/blob/20c21b12fd8476a03c02579cda806746e7204d24/scripts/xflock4) version [shipped by Ubuntu](https://packages.ubuntu.com/jammy/xfce4-session) (which contains more command than xfce's version). Additionally, I've added physlock as a last-resort fallback.

In my testing the order seems to be relevant, since XUbuntu 22.04 ships with a xdg-screensaver version that doesn't support the lock option (you get an error message and exit code 4 instead), but it does support xfce4-screensaver-command.


Aside: xflock4 also first tries to find a lock command configured in xfconf, by calling `xfconf-query -c xfce4-session -p /general/LockCommand`. That doesn't neatly fit into what this library is doing so far, so I didn't add it here, but I think it's an interesting option to explore.